### PR TITLE
[#14] Master, Slave 데이터베이스 연결 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,40 @@
 version: '3.8'
 services:
   mysql-master:
-    image: mysql:8.0
+    build:
+      context: ./
+      dockerfile: docker/master/Dockerfile
+    restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: bidnamu
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: root
     ports:
       - "3307:3306"
+    volumes:
+      - master:/var/lib/mysql
+      - master:/var/lib/mysql-files
+    networks:
+      - net-mysql
 
   mysql-slave:
-    image: mysql:8.0
+    build:
+      context: ./
+      dockerfile: docker/slave/Dockerfile
+    restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: bidnamu
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+      MYSQL_ROOT_PASSWORD: root
     ports:
       - "3308:3306"
+    volumes:
+      - slave:/var/lib/mysql
+      - slave:/var/lib/mysql-files
+    networks:
+      - net-mysql
 
   redis-cache:
     image: redis:7.2-alpine
@@ -27,3 +47,11 @@ services:
     command: redis-server --port 6380
     ports:
       - "6380:6380"
+
+volumes:
+  master:
+  slave:
+
+networks:
+  net-mysql:
+    driver: bridge

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -1,0 +1,2 @@
+FROM mysql:8.0
+ADD /docker/master/my.cnf /etc/mysql/my.cnf

--- a/docker/master/my.cnf
+++ b/docker/master/my.cnf
@@ -1,0 +1,5 @@
+[mysqld]
+log_bin = mysql-bin
+server_id = 1
+binlog_do_db = bidnamu
+default_authentication_plugin = mysql_native_password

--- a/docker/slave/Dockerfile
+++ b/docker/slave/Dockerfile
@@ -1,0 +1,2 @@
+FROM mysql:8.0
+ADD /docker/slave/my.cnf /etc/mysql/my.cnf

--- a/docker/slave/my.cnf
+++ b/docker/slave/my.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+log_bin = mysql-bin
+server_id = 11
+relay_log = /var/lib/mysql/mysql-relay-bin
+log_slave_updates = 'ON'
+read_only = 'ON'
+default_authentication_plugin = mysql_native_password

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,15 +4,15 @@ spring:
       hikari:
         driver-class-name: com.mysql.cj.jdbc.Driver
         jdbc-url: jdbc:mysql://localhost:3307/bidnamu
-        username: root
-        password: root
+        username: user
+        password: password
 
     slave:
       hikari:
         driver-class-name: com.mysql.cj.jdbc.Driver
         jdbc-url: jdbc:mysql://localhost:3308/bidnamu
-        username: root
-        password: root
+        username: user
+        password: password
 
   redis:
     cache:


### PR DESCRIPTION
#14
- `docker-compose`를 통해 두 데이터베이스 간 네트워킹 및 로그 설정
- 동기화 자체는 컨테이너 내에 접속하여 설정 필요 (노션 참고)
- 서버의 DB 접속을 `root`로 접속하는 것이 아닌 `user`로 접속하도록 변경